### PR TITLE
Add Big Tujunga DEM

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tif filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 If you are looking for the digital elevation models used in TopoToolbox documentation and examples, check out the [TopoToolbox/DEMs](https://github.com/TopoToolbox/DEMs) repository.
 
 This repository provides digital elevation models and derivative products for snapshot testing of TopoToolbox.
+
+Data are stored as GeoTIFFs and managed using [Git Large File Storage](https://git-lfs.com/). If you clone this repository without Git LFS installed on your computer, you will not receive the data, but pointers to the GeoTIFF files stored on GitHub.
+
+Snapshot datasets are located in subdirectories within this repository. The original digital elevation model should be stored in a file called `dem.tif`. Derivatives of this DEM are created by an automated MATLAB test script in [TopoToolbox/topotoolbox3](https://github.com/TopoToolbox/topotoolbox3) and have names derived from the functions used to create them.

--- a/bigtujunga_30m/dem.tif
+++ b/bigtujunga_30m/dem.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9a25b3471c5ba237bd621ec036d6b4986dee0290f9030d553e36505e1bc04ab
+size 1967049


### PR DESCRIPTION
bigtujunga_30m/dem.tif is the Big Tujunga DEM included with TopoToolbox 2. It is managed using Git Large File Storage.

Derivative DEMs will be added once the snapshot tests are merged into topotoolbox3.